### PR TITLE
NOT READY - [DM-20583] Add TAP client wrapper

### DIFF
--- a/jupyterlabutils/notebook/__init__.py
+++ b/jupyterlabutils/notebook/__init__.py
@@ -1,6 +1,7 @@
 """
 Collection of notebook utilities
 """
+from .catalog import get_catalog, retrieve_query
 from .clusterproxy import ClusterProxy
 from .forwarder import Forwarder
 from .lsstdaskclient import LSSTDaskClient
@@ -8,4 +9,5 @@ from .utils import format_bytes, get_proxy_url, get_hostname, \
     show_with_bokeh_server
 
 __all__ = [ClusterProxy, Forwarder, LSSTDaskClient, format_bytes,
-           get_proxy_url, get_hostname, show_with_bokeh_server]
+           get_catalog, retrieve_query, get_proxy_url, get_hostname,
+           show_with_bokeh_server]

--- a/jupyterlabutils/notebook/catalog.py
+++ b/jupyterlabutils/notebook/catalog.py
@@ -1,0 +1,27 @@
+import requests
+import os
+import pyvo
+import pyvo.extensions.auth.authsession
+
+def _get_tap_url():
+    if 'EXTERNAL_TAP_URL' in os.environ:
+        return os.environ['EXTERNAL_TAP_URL']
+    else:
+        return os.environ['EXTERNAL_INSTANCE_URL'] + os.environ['TAP_ROUTE']
+
+def _get_auth():
+    tap_url = _get_tap_url()
+    s = requests.Session()
+    s.headers['Authorization'] = 'Bearer ' + os.environ['ACCESS_TOKEN']
+    auth = pyvo.extensions.auth.authsession.AuthSession()
+    auth.credentials.set('lsst-token', s)
+    auth.add_security_method_for_url(tap_url, 'lsst-token')
+    auth.add_security_method_for_url(tap_url + '/sync', 'lsst-token')
+    auth.add_security_method_for_url(tap_url + '/async', 'lsst-token')
+    return auth
+
+def get_catalog():
+    return pyvo.dal.TAPService(_get_tap_url(), _get_auth())
+
+def retrieve_query(query_url):
+    return pyvo.dal.AsyncTAPJob(query_url, _get_auth())

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ setuptools.setup(
         'maproxy',
         'dask>=2.0.0',
         'distributed>=2.0.0',
-        'pyvo>=1.0.0',
         'requests>=2.22.0'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,8 @@ setuptools.setup(
         'bokeh>=0.12.15',
         'maproxy',
         'dask>=2.0.0',
-        'distributed>=2.0.0'
+        'distributed>=2.0.0',
+        'pyvo>=1.0.0',
+        'requests>=2.22.0'
     ],
 )


### PR DESCRIPTION
This adds a function, get_catalog.  This will assume it is being
run in the LSP notebook environment, and uses environment variables
from the environment to determine the URL to the TAP service, as
well as hook up the auth.

Note this requires new pyvo features.