### PR TITLE
[DM-21829] Fix service.describe() auth problem

### DIFF
--- a/jupyterlabutils/_version.py
+++ b/jupyterlabutils/_version.py
@@ -1,5 +1,5 @@
 """
 Version information.
 """
-version_info = (0, 5, 0)
+version_info = (0, 5, 1)
 __version__ = '.'.join(map(str, version_info))

--- a/jupyterlabutils/notebook/catalog.py
+++ b/jupyterlabutils/notebook/catalog.py
@@ -18,6 +18,7 @@ def _get_auth():
     auth.add_security_method_for_url(tap_url, 'lsst-token')
     auth.add_security_method_for_url(tap_url + '/sync', 'lsst-token')
     auth.add_security_method_for_url(tap_url + '/async', 'lsst-token')
+    auth.add_security_method_for_url(tap_url + '/tables', 'lsst-token')
     return auth
 
 def get_catalog():


### PR DESCRIPTION
Apparently service.describe() goes to the /tables endpoint, and since
that wasn't listed here, it wasn't putting the token on those requests.
That would make it fail.  So add that URL to the list of URLs that should
have the token added to it.