### PR TITLE
[DM-22538] Replace access token logic

### DIFF
--- a/jupyterlabutils/_version.py
+++ b/jupyterlabutils/_version.py
@@ -1,5 +1,5 @@
 """
 Version information.
 """
-version_info = (0, 10, 0)
+version_info = (0, 11, 0)
 __version__ = ".".join(map(str, version_info))

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setuptools.setup(
         "pyvo>=1.0",
         "requests>=2.18",
         "jupyterlab>=2.2,<3",
-        "jupyterhubutils>=0.24.1",
         "semver",
     ],
     entry_points={


### PR DESCRIPTION
We no longer use JWTs inside the Science Platform and are working
on retiring jupyterhubutils.  Get the access token from the path
where it is mounted in the lab container by default and fall back
on the ACCESS_TOKEN environment variable.  Do not attempt to parse
or validate it (there doesn't seem to be much point just to change
the exception the user will get if it's not valid), but throw an
exception if no token could be found.